### PR TITLE
Flip andthenk

### DIFF
--- a/src/Return.elm
+++ b/src/Return.elm
@@ -1,31 +1,11 @@
-module Return
-    exposing
-        ( Return
-        , ReturnF
-        , andMap
-        , andThen
-        , andThenK
-        , command
-        , dropCmd
-        , effect_
-        , flatten
-        , map
-        , map2
-        , map3
-        , map4
-        , map5
-        , mapBoth
-        , mapCmd
-        , mapWith
-        , pipel
-        , pipelK
-        , piper
-        , piperK
-        , return
-        , sequence
-        , singleton
-        , zero
-        )
+module Return exposing
+    ( Return, ReturnF
+    , map, map2, map3, map4, map5, andMap, mapWith, mapCmd, mapBoth, dropCmd
+    , piper, pipel, zero, piperK, pipelK
+    , singleton, andThen, andThenK
+    , return, command, effect_
+    , sequence, flatten
+    )
 
 {-|
 
@@ -142,9 +122,9 @@ mapBoth f f_ ( model, cmd ) =
 {-| Combine 2 `Return`s with a function
 
     map2
-      (\modelA modelB -> { modelA | foo = modelB.foo })
-      retA
-      retB
+        (\modelA modelB -> { modelA | foo = modelB.foo })
+        retA
+        retB
 
 -}
 map2 :
@@ -290,19 +270,22 @@ flatten =
     andThen identity
 
 
-{-| Kleisli composition  -}
-andThenK : (a -> Return x b) -> (b -> Return x c) -> (a -> Return x c)
-andThenK x y a =
+{-| Kleisli composition
+-}
+andThenK : (b -> Return x c) -> (a -> Return x b) -> (a -> Return x c)
+andThenK y x a =
     x a |> andThen y
 
 
-{-| Compose updaters from the left -}
+{-| Compose updaters from the left
+-}
 pipelK : List (a -> Return x a) -> (a -> Return x a)
 pipelK =
     List.foldl andThenK singleton
 
 
-{-| Compose updaters from the right -}
+{-| Compose updaters from the right
+-}
 piperK : List (a -> Return x a) -> (a -> Return x a)
 piperK =
     List.foldr andThenK singleton

--- a/src/Return.elm
+++ b/src/Return.elm
@@ -1,7 +1,7 @@
 module Return exposing
     ( Return, ReturnF
     , map, map2, map3, map4, map5, andMap, mapWith, mapCmd, mapBoth, dropCmd
-    , piper, pipel, zero, piperK, pipelK
+    , piper, pipel, zero, piperK, pipelK, concatK
     , singleton, andThen, andThenK
     , return, command, effect_
     , sequence, flatten
@@ -24,7 +24,7 @@ Modeling the `update` tuple as a Monad similar to `Writer`
 
 ## Piping
 
-@docs piper, pipel, zero, piperK, pipelK
+@docs piper, pipel, zero, piperK, pipelK, concatK
 
 
 ## Basics
@@ -275,6 +275,20 @@ flatten =
 andThenK : (b -> Return x c) -> (a -> Return x b) -> (a -> Return x c)
 andThenK y x a =
     x a |> andThen y
+
+
+{-| Compose a list of updaters.
+
+    concatK [ doFirst, doSecond ]
+
+is equivalent to
+
+    andThen doFirst >> andThen doSecond
+
+-}
+concatK : List (a -> Return x a) -> (a -> Return x a)
+concatK =
+    pipelK
 
 
 {-| Compose updaters from the left


### PR DESCRIPTION
Two things:

I believe the arguments to `andThenK` were the wrong way around, which caused pipelK and piperK to have the opposite semantics to their naming and documentation. I've flipped them here.

Also, composing a list of updaters together from the left is a common and useful operation (for me at least), thus I propose calling it `concatK` to make it more approachable. This name was inspired by [a Hoogle search for a similar type](https://hoogle.haskell.org/?hoogle=Monad+m+=%3E+%5Ba+-%3E+m+a%5D+-%3E+a+-%3E+m+a).

Resolves #17.
